### PR TITLE
Include X-PJAX-CONTAINER element in the response

### DIFF
--- a/src/JacobBennett/Pjax/PjaxMiddleware.php
+++ b/src/JacobBennett/Pjax/PjaxMiddleware.php
@@ -42,7 +42,7 @@ class PjaxMiddleware {
                     }
 
                     // Set new content for the response
-                    $response->setContent($title . $response_container->html());
+                    $response->setContent($title . $response_container->getNode(0)->ownerDocument->saveHTML($response_container->getNode(0)));
                 }
 
                 // Updating address bar with the last URL in case there were redirects


### PR DESCRIPTION
Pjax (or at least jquery-pjax) requires the pjax container element to be included in the response. As stated in the documentation, pjax will force a full reload if the fragment is not found:

> Page content that includes <html> when fragment selector wasn't explicitly configured. Pjax presumes that the server's response hasn't been properly configured for pjax. If fragment pjax option is given, pjax will simply extract the content to insert into the DOM based on that selector.
> - https://github.com/defunkt/jquery-pjax#response-types-that-force-a-reload

Also see the code: https://github.com/defunkt/jquery-pjax/blob/master/jquery.pjax.js#L714
