### PR TITLE
Use methods provided Laravel 

### DIFF
--- a/src/JacobBennett/Pjax/PjaxMiddleware.php
+++ b/src/JacobBennett/Pjax/PjaxMiddleware.php
@@ -22,15 +22,14 @@ class PjaxMiddleware {
         // Only handle non-redirections
         if (!$response->isRedirection()) {
             // Must be a pjax-request
-            if ($request->server->get('HTTP_X_PJAX')) {
-//                return $response;
+            if ($request->pjax()) {
                 $crawler = new Crawler($response->getContent());
 
                 // Filter to title (in order to update the browser title bar)
                 $response_title = $crawler->filter('head > title');
 
                 // Filter to given container
-                $response_container = $crawler->filter($request->server->get('HTTP_X_PJAX_CONTAINER'));
+                $response_container = $crawler->filter($request->header('X-PJAX-CONTAINER'));
 
                 // Container must exist
                 if ($response_container->count() != 0) {


### PR DESCRIPTION
A small fix to use the high-level laravel methods instead of low-level methods to retrieve/check for the pjax headers.
