### PR TITLE
Need to get the content of the container.

### DIFF
--- a/src/JacobBennett/Pjax/PjaxMiddleware.php
+++ b/src/JacobBennett/Pjax/PjaxMiddleware.php
@@ -41,7 +41,7 @@ class PjaxMiddleware {
                     }
 
                     // Set new content for the response
-                    $response->setContent($title . $response_container->getNode(0)->ownerDocument->saveHTML($response_container->getNode(0)));
+                    $response->setContent($title . $response_container->html());
                 }
 
                 // Updating address bar with the last URL in case there were redirects


### PR DESCRIPTION
Need to get the content of the container, not the actual container. Getting the entire container results in the injected HTML looking like this:

``` html
<div id="container">
  <div id="container">...</div>
</div>
```

Changed it to match what was done in the Laravel 4 version.
